### PR TITLE
resolve URLs passed to hyperquest

### DIFF
--- a/lib/npm-proxy.js
+++ b/lib/npm-proxy.js
@@ -366,7 +366,7 @@ NpmProxy.prototype.standardWriteUrl = function (pkg, policy, callback) {
   // - if it does exist then we proxy to the public registry
   //
   hyperquest({
-    uri: this.writeNpm.href + '/' + pkg,
+    uri: url_.resolve(this.writeNpm.href, pkg),
     rejectUnauthorized: this.secure
   })
   .on('error', callback)
@@ -465,7 +465,7 @@ NpmProxy.prototype.whitelistWriteUrl = function (pkg, policy, callback) {
   // - if it does exist then we 404
   //
   hyperquest({
-    uri: this.writeNpm.href + '/' + pkg,
+    uri: url_.resolve(this.writeNpm.href, pkg),
     rejectUnauthorized: this.secure
   })
   .on('error', callback)


### PR DESCRIPTION
The normalized this.writeNpm.href has an ending slash. As a slash was
appended to this string (along with the package name), the URL passed to
hyperquest contained two slashes after the hostname. For example:

    http://registry.npmjs.com//smart-private-npm

The router used by registry3 now responds with a 500 error to this type
of request.

By resolving the package name with the registry URL, we obtain URLs that
the registry3 router accepts.

    http://registry.npmjs.com/smart-private-npm